### PR TITLE
🎨 Palette: Add ARIA labels to playback control buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-05 - Material Icons and Screen Readers
+**Learning:** Material Icon ligatures (e.g., `skip_previous`) placed inside buttons will be literally read aloud by screen readers if not hidden, creating a confusing and unpleasant experience for visually impaired users.
+**Action:** Always add `aria-hidden="true"` to the icon `span` element and pair it with a descriptive `aria-label` on the parent `<button>` for icon-only buttons.

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -384,22 +384,22 @@
                   </div>
                   <div class="bottom-controls">
                     <div class="left-controls">
-                      <button class="control-button prev-btn">
-                        <span class="material-symbols-outlined"
+                      <button class="control-button prev-btn" aria-label="Previous track">
+                        <span class="material-symbols-outlined" aria-hidden="true"
                           >skip_previous</span
                         >
                       </button>
-                      <button class="control-button play-pause-btn">
-                        <span class="material-symbols-outlined"
+                      <button class="control-button play-pause-btn" aria-label="Play or pause">
+                        <span class="material-symbols-outlined" aria-hidden="true"
                           >play_arrow</span
                         >
                       </button>
-                      <button class="control-button next-btn">
-                        <span class="material-symbols-outlined">skip_next</span>
+                      <button class="control-button next-btn" aria-label="Next track">
+                        <span class="material-symbols-outlined" aria-hidden="true">skip_next</span>
                       </button>
                       <div class="volume-container">
-                        <button class="control-button mute-btn">
-                          <span class="material-symbols-outlined"
+                        <button class="control-button mute-btn" aria-label="Mute or unmute">
+                          <span class="material-symbols-outlined" aria-hidden="true"
                             >volume_up</span
                           >
                         </button>


### PR DESCRIPTION
This PR implements a UX and accessibility enhancement for the application's media player controls. 

- **Problem:** Icon-only buttons using Material Symbols were missing ARIA labels. Screen readers would literally dictate the ligature text inside the `span` (e.g., "play arrow", "skip previous"), resulting in poor user experience for visually impaired users.
- **Solution:** Added descriptive `aria-label` attributes to the Previous, Play/Pause, Next, and Mute buttons in `src/renderer/index.html`. Added `aria-hidden="true"` to the inner Material Icon `<span>` tags to prevent redundant screen reader vocalization.
- **Learnings:** Created `.jules/palette.md` to document the necessity of pairing `aria-hidden` on Material Icons with `aria-label`s on their parent interactive elements.

---
*PR created automatically by Jules for task [8232536088535095407](https://jules.google.com/task/8232536088535095407) started by @rootLocalGhost*